### PR TITLE
#8935 Feat add jump to training platform

### DIFF
--- a/web/.gitignore
+++ b/web/.gitignore
@@ -1,3 +1,5 @@
 /node_modules
 yarn.lock
 build
+
+.windsurf

--- a/web/public/appsetting.json
+++ b/web/public/appsetting.json
@@ -3,6 +3,6 @@
   "tokenKey": "token",
   "userNameKey": "userName",
   "cameraAIBackstageDomain": "https://camerai-m.wiltechs.com/",
-  "trainingPlatformUrl": "https://train-platform.wiltechs.com",
+  "trainingPlatformUrl": "https://train-platform.wiltechs.com/auth",
   "omeAccountServerUrl": "https://ome-account.wiltechs.com"
 }

--- a/web/public/appsetting.json
+++ b/web/public/appsetting.json
@@ -3,6 +3,6 @@
   "tokenKey": "token",
   "userNameKey": "userName",
   "cameraAIBackstageDomain": "https://camerai-m.wiltechs.com/",
-  "trainingPlatformUrl": "",
+  "trainingPlatformUrl": "https://train-platform.wiltechs.com",
   "omeAccountServerUrl": "https://ome-account.wiltechs.com"
 }

--- a/web/public/appsetting.json
+++ b/web/public/appsetting.json
@@ -2,5 +2,7 @@
   "serverUrl": "https://testsmarties.yamimeal.ca",
   "tokenKey": "token",
   "userNameKey": "userName",
-  "cameraAIBackstageDomain": "https://camerai-m.wiltechs.com/"
+  "cameraAIBackstageDomain": "https://camerai-m.wiltechs.com/",
+  "trainingPlatformUrl": "",
+  "omeAccountServerUrl": "https://ome-account.wiltechs.com"
 }

--- a/web/src/appsetting.ts
+++ b/web/src/appsetting.ts
@@ -2,6 +2,8 @@ export interface IAppSettings {
   serverUrl: string;
   tokenKey: string;
   userNameKey: string;
+  trainingPlatformUrl: string;
+  omeAccountServerUrl: string;
 }
 
 const settings = (window as any).appsettings;

--- a/web/src/pages/main/hook.ts
+++ b/web/src/pages/main/hook.ts
@@ -198,10 +198,9 @@ export const useAction = () => {
 
   const jumpToTrainingPlatform = () => {
     const settings = (window as any).appsettings;
-
     CreateMyTicketApi()
       .then((tk) => {
-        const url = `${settings.trainingPlatformUrl}?userTicket=${tk}`;
+        const url = `${settings.trainingPlatformUrl}/auth?ticket=${tk?.ticket}`;
 
         window.open(url, "_blank");
       })

--- a/web/src/pages/main/hook.ts
+++ b/web/src/pages/main/hook.ts
@@ -200,7 +200,7 @@ export const useAction = () => {
     const settings = (window as any).appsettings;
     CreateMyTicketApi()
       .then((tk) => {
-        const url = `${settings.trainingPlatformUrl}/auth?ticket=${tk?.ticket}`;
+        const url = `${settings.trainingPlatformUrl}?ticket=${tk?.ticket}`;
 
         window.open(url, "_blank");
       })

--- a/web/src/pages/main/hook.ts
+++ b/web/src/pages/main/hook.ts
@@ -1,14 +1,13 @@
 import { useDebounceFn, useUpdateEffect } from "ahooks";
 import { useEffect, useState } from "react";
 
-import { useAuth } from "@/hooks/use-auth";
-import { App } from "antd";
 import {
   IAcceptWarnDtoProps,
   IAddTeamDataProps,
   INewTeamDtoProps,
   IUserProfileNotificationDto,
 } from "@/dtos/main";
+import { useAuth } from "@/hooks/use-auth";
 import {
   GetAccountInfoApi,
   GetUserNotificationApi,
@@ -16,6 +15,8 @@ import {
   PostUploadApi,
   PostUserNotificationUpdateApi,
 } from "@/services/main";
+import { CreateMyTicketApi } from "@/services/ome-account";
+import { App } from "antd";
 import { isEmpty } from "ramda";
 
 const initAcceptWarn: IUserProfileNotificationDto = {
@@ -106,7 +107,7 @@ export const useAction = () => {
 
   const updateErrorMessage = (
     k: keyof IUserProfileNotificationDto,
-    v: string
+    v: string,
   ) => {
     setErrorMessages((prev) => ({
       ...prev,
@@ -116,7 +117,7 @@ export const useAction = () => {
 
   const updateAcceptWarnData = (
     k: keyof IUserProfileNotificationDto,
-    v: string
+    v: string,
   ) => {
     setAcceptWarnData((prev) => ({
       ...prev,
@@ -148,7 +149,7 @@ export const useAction = () => {
 
   const validateFn = (
     type: keyof IUserProfileNotificationDto,
-    value: string
+    value: string,
   ) => {
     const rule = validationRules[type];
 
@@ -188,12 +189,33 @@ export const useAction = () => {
     () => location.pathname !== "/warning/list" && navigate("/warning/list"),
     {
       wait: 500,
-    }
+    },
   );
 
   const { run: handleJumpToBackstage } = useDebounceFn(jumpToBackstage, {
     wait: 500,
   });
+
+  const jumpToTrainingPlatform = () => {
+    const settings = (window as any).appsettings;
+
+    CreateMyTicketApi()
+      .then((tk) => {
+        const url = `${settings.trainingPlatformUrl}?userTicket=${tk}`;
+
+        window.open(url, "_blank");
+      })
+      .catch((err) => {
+        message.error(`跳轉訓練平台失敗：${err}`);
+      });
+  };
+
+  const { run: handleJumpToTrainingPlatform } = useDebounceFn(
+    jumpToTrainingPlatform,
+    {
+      wait: 500,
+    },
+  );
 
   const filterSelectKey = (key: string) => {
     if (!["/home", "/monitor", "/replay"].includes(key)) {
@@ -255,7 +277,7 @@ export const useAction = () => {
           updateAddTeamData("name", "");
         });
     },
-    { wait: 500 }
+    { wait: 500 },
   );
 
   const { run: onAcceptWarnDebounceFn } = useDebounceFn(
@@ -279,7 +301,7 @@ export const useAction = () => {
           updateAcceptWarnDto("openAcceptWran", false);
         });
     },
-    { wait: 500 }
+    { wait: 500 },
   );
 
   const getMineInfo = () => {
@@ -290,7 +312,7 @@ export const useAction = () => {
 
           localStorage.setItem(
             "currentAccount",
-            JSON.stringify(res.userProfile)
+            JSON.stringify(res.userProfile),
           );
         }
       })
@@ -372,6 +394,7 @@ export const useAction = () => {
     handleOnSignOut,
     pagePermission,
     handleJumpToBackstage,
+    handleJumpToTrainingPlatform,
     addTeamData,
     acceptWarnData,
     errorMessages,

--- a/web/src/pages/main/index.tsx
+++ b/web/src/pages/main/index.tsx
@@ -7,14 +7,14 @@ import {
   Avatar,
   Button,
   ConfigProvider,
+  Image,
   Input,
   Menu,
   MenuProps,
   Modal,
   Popover,
-  Image,
-  Tooltip,
   Spin,
+  Tooltip,
   message,
 } from "antd";
 import { useMemo } from "react";
@@ -23,6 +23,17 @@ import { Link, Outlet } from "react-router-dom";
 import { useAuth } from "@/hooks/use-auth";
 import KEYS from "@/i18n/keys/main-page";
 
+import {
+  AddTeamIcon,
+  ArrowRightIcon,
+  CloseNewTeamIcon,
+  LogoutIcon,
+  PreviewAndAcceptIcon,
+  RefreshIcon,
+  SelectedIcon,
+  UpoadLogoIcon,
+  UserArrowRightIcon,
+} from "@/icon/main";
 import chevronDownImg from "../../assets/chevronDown.png";
 import homeImg from "../../assets/home.png";
 import home_clickImg from "../../assets/home_click.png";
@@ -35,20 +46,9 @@ import replayImg from "../../assets/replay.png";
 import replay_clickImg from "../../assets/replay_click.png";
 import sliceImg from "../../assets/slice.png";
 import { useAction } from "./hook";
-import {
-  AddTeamIcon,
-  ArrowRightIcon,
-  CloseNewTeamIcon,
-  LogoutIcon,
-  PreviewAndAcceptIcon,
-  RefreshIcon,
-  SelectedIcon,
-  UpoadLogoIcon,
-  UserArrowRightIcon,
-} from "@/icon/main";
 
-import Dropzone from "react-dropzone";
 import { isEmpty } from "ramda";
+import Dropzone from "react-dropzone";
 
 type MenuItem = Required<MenuProps>["items"][number];
 
@@ -69,6 +69,7 @@ export const Main = () => {
     handleOnSignOut,
     pagePermission,
     handleJumpToBackstage,
+    handleJumpToTrainingPlatform,
     addTeamData,
     acceptWarnData,
     errorMessages,
@@ -426,6 +427,7 @@ export const Main = () => {
                           handleJumpToBackstage();
                         },
                       },
+
                       {
                         name: "預警接收",
                         component: <PreviewAndAcceptIcon />,
@@ -446,13 +448,20 @@ export const Main = () => {
                           }
                         },
                       },
+                      {
+                        name: "訓練平台",
+                        component: <SwapOutlined className="text-sm" />,
+                        function: () => {
+                          handleJumpToTrainingPlatform();
+                        },
+                      },
                     ]
                       .filter(
                         (item) =>
                           !(
                             userName.toLowerCase() === "admin" &&
                             item.name === "預警接收"
-                          )
+                          ),
                       )
                       .map((item, index) => (
                         <div
@@ -521,7 +530,7 @@ export const Main = () => {
 
                                 message.info(
                                   `即将切换到 ${item.name} ......`,
-                                  0
+                                  0,
                                 );
 
                                 const interval = setInterval(() => {
@@ -819,7 +828,7 @@ export const Main = () => {
                   onClick={() => {
                     updateAcceptWarnData(
                       "workWechat",
-                      originAcceptWarnData.workWechat
+                      originAcceptWarnData.workWechat,
                     );
                     updateErrorMessage("workWechat", "");
                   }}

--- a/web/src/services/ome-account.ts
+++ b/web/src/services/ome-account.ts
@@ -1,0 +1,27 @@
+export const CreateMyTicketApi = async (): Promise<string> => {
+  const settings = (window as any).appsettings;
+
+  const token = window.__POWERED_BY_WUJIE__
+    ? window.$wujie.props?.token
+    : localStorage.getItem(settings?.tokenKey);
+
+  const response = await fetch(
+    `${settings.omeAccountServerUrl}/app/api/my-tickets`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({}),
+    },
+  );
+
+  if (!response.ok) {
+    throw new Error("獲取票據失敗");
+  }
+
+  const data = await response.json();
+
+  return data;
+};

--- a/web/src/services/ome-account.ts
+++ b/web/src/services/ome-account.ts
@@ -1,4 +1,9 @@
-export const CreateMyTicketApi = async (): Promise<string> => {
+interface IMyTicketProps {
+  ticket: string;
+  expireIn: number;
+}
+
+export const CreateMyTicketApi = async (): Promise<IMyTicketProps> => {
   const settings = (window as any).appsettings;
 
   const token = window.__POWERED_BY_WUJIE__


### PR DESCRIPTION
## 变更内容

新增跳转训练平台功能，用户可通过个人菜单点击「训练平台」跳转至外部训练平台页面。

### 主要改动
- 新增 `ome-account` 服务，用于获取用户票据
- 在应用配置中新增 `trainingPlatformUrl` 和 `omeAccountServerUrl` 配置项
- 在主页面用户菜单中新增「训练平台」入口

Close #102